### PR TITLE
Docker under v1.12 can't build with symbolic link file

### DIFF
--- a/ceph-releases/jewel/ubuntu/16.04/base/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/16.04/base/entrypoint.sh
@@ -1,1 +1,6 @@
-../../14.04/base/entrypoint.sh
+#!/bin/sh
+if [ -z "$1" ]; then
+  /bin/bash
+else
+  $@
+fi


### PR DESCRIPTION
When building a docker image, the process can't find symbolic link file.
We only tried docker v1.12 & v1.10.
Replace the "entrypoint.sh" with real file until we solve this problem.