### PR TITLE
Fix problem that mon didn't find monmap.

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/mon.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/mon.sh
@@ -88,11 +88,16 @@ function update_etcd_monmap {
 ## MAIN
 function cdx_mon {
   get_mon_ip_from_public
+
   if [ "${KV_TYPE}" == "etcd" ]; then
     populate_etcd
     remove_mon_lock
     verify_mon_folder
     update_monmap
     update_etcd_monmap boot&
+  fi
+
+  if [ -e "$MON_DATA_DIR/keyring" ]; then
+    get_mon_config
   fi
 }


### PR DESCRIPTION
When mon keyring existing in $MON_DATA_DIR, monitor skip getting ceph data in /etc/ceph.
Therefore we check it before running.