### PR TITLE
Recovery mon

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/Dockerfile
@@ -2,7 +2,7 @@
 # CEPH VERSION: Jewel
 # CEPH VERSION DETAIL: 10.2.x
 
-FROM cdxvirt/ceph-base:base-10.2.10-1
+FROM cdxvirt/ceph-base:base-10.2.10-2
 MAINTAINER Sébastien Han "seb@redhat.com"
 
 # Add bootstrap script, ceph defaults key/values for KV store

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/README.md
@@ -34,7 +34,7 @@ $ docker run -it --net=host --privileged=true -e CDX_ENV=true -e CEPH_VFY=all \
 ## TOOLS
 ### Fix MON
 ```txt
-$ docker run -it --net=host -e CDX_ENV=true -e DEBUG=verbose -e MON_RCY=true \
+$ docker run -it --net=host -e CDX_ENV=true -e MON_RCY=true \
   -e CEPH_PUBLIC_NETWORK="192.168.0.0/24" -v /var/lib/ceph:/var/lib/ceph \
   cdxvirt/ceph-daemon:latest cdx_mon
 ```

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/README.md
@@ -31,6 +31,14 @@ $ docker run -it --net=host --privileged=true -e CDX_ENV=true -e CEPH_VFY=all \
   -v /lib/modules/:/lib/modules/ -v /dev:/dev cdxvirt/ceph-daemon:latest cdx_verify
 ```
 
+## TOOLS
+### Fix MON
+```txt
+$ docker run -it --net=host -e CDX_ENV=true -e DEBUG=verbose -e MON_RCY=true \
+  -e CEPH_PUBLIC_NETWORK="192.168.0.0/24" -v /var/lib/ceph:/var/lib/ceph \
+  cdxvirt/ceph-daemon:latest cdx_mon
+```
+
 ## API
 ### OSD
 ```txt
@@ -69,7 +77,7 @@ OPTS =>
 
 ## CDX ENTRYPOINT
 ### cdx_mon
-Brfore running start_mon, check monip, monmap first.
+Before running start_mon, check monip, monmap first.
 ### cdx_osd
 Choose disk, zap disk, and activate disk in different containers.
 ### cdx_controller

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/mon.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/mon.sh
@@ -89,22 +89,28 @@ function recovery_mon {
   verify_mon_folder
 
   # remove all monmap list then add itself
-  ceph-mon -i ${MON_NAME} --extract-monmap /tmp/monmap
+  log "Remove old monitor info on the monmap"
+  ceph-mon -i ${MON_NAME} --extract-monmap /tmp/monmap &>/dev/null
   local MONMAP_LIST=$(monmaptool -p /tmp/monmap | awk '/mon\./ { sub ("mon.", "", $3); print $3}')
   for del_mon in ${MONMAP_LIST}; do
-    monmaptool --rm $del_mon /tmp/monmap
+    monmaptool --rm $del_mon /tmp/monmap &>/dev/null
   done
 
   # add itself into monmap
-  monmaptool --add ${MON_NAME} ${MON_IP}:6789 /tmp/monmap
-  ceph-mon -i ${MON_NAME} --inject-monmap /tmp/monmap
+  log "Update monitor info in the monmap"
+  monmaptool --add ${MON_NAME} ${MON_IP}:6789 /tmp/monmap &>/dev/null
+  ceph-mon -i ${MON_NAME} --inject-monmap /tmp/monmap &>/dev/null
+  echo ""
+  monmaptool -p /tmp/monmap
 
   # update ETCD (include monmap & mon_host)
   if uuencode /tmp/monmap - | etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}"/monmap &>/dev/null; then
-    etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" rm "${CLUSTER_PATH}"/mon_host --recursive
-    log "Updated monmap on ETCD."
+    etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" rm "${CLUSTER_PATH}"/mon_host --recursive &>/dev/null || true
+    echo ""
+    log "Success & Exit"
   else
-    log "ERROR- Failed to update monmap on ETCD."
+    log "ERROR- Fail to upload monmap to ETCD"
+    exit 1
   fi
 }
 

--- a/ceph-releases/jewel/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/16.04/daemon/Dockerfile
@@ -4,7 +4,7 @@
 #
 # VERSION 0.0.1
 
-FROM cdxvirt/ceph-base:base-10.2.10-1
+FROM cdxvirt/ceph-base:base-10.2.10-2
 MAINTAINER Sébastien Han "seb@redhat.com"
 
 # Add bootstrap script, ceph defaults key/values for KV store


### PR DESCRIPTION
A new tool for recovering ceph monitors.

By using MON_RCY=true, container ceph-daemon will update monmap.
After updating monmap, ceph monitor could start running normally.