### PR TITLE
Improve ceph init

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/api.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/api.sh
@@ -28,6 +28,19 @@ function cdx_ceph_api {
       # Cache pool commands
       $@
       ;;
+    create_bench_crush|backup_crushmap|recovery_crushmap|create_bench_pool|remove_bench_pool)
+      # For Ceph Auto Bench
+      source cdx/auto-bench.sh
+      local CMD=$1
+      local BENCH_OSD_TYPE=$2
+      local OSD_NUM=$3
+      local STAMP=$4
+      local REPLICA=$5
+      local PG_NUM=$6
+      : "${REPLICA:=3}"
+      : "${PG_NUM:=128}"
+      ${CMD}
+      ;;
     *)
       log "WARN- Wrong options. See function cdx_ceph_api."
       return 2

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/api.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/api.sh
@@ -425,6 +425,7 @@ function link_cache_tier {
   ceph "${CLI_OPTS[@]}" osd tier cache-mode "${CACHE_POOL}" writeback &>/dev/null
   ceph "${CLI_OPTS[@]}" osd tier set-overlay "${TARGET_POOL}" "${CACHE_POOL}" >/dev/null
   ceph "${CLI_OPTS[@]}" osd pool set "${CACHE_POOL}" hit_set_type bloom &>/dev/null
+  ceph "${CLI_OPTS[@]}" osd pool set "${CACHE_POOL}" target_max_bytes 1099511627776 &>/dev/null
   echo "SUCCESS"
 }
 

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/auto-bench.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/auto-bench.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Need $BENCH_OSD_TYPE $OSD_NUM $STAMP $REPLICA $PG_NUM
+
+function create_bench_crush {
+  # Create rules
+  ceph "${CLI_OPTS[@]}" osd crush add-bucket CEPH-AUTO-BENCH root
+  ceph "${CLI_OPTS[@]}" osd crush rule create-simple ceph_auto_bench CEPH-AUTO-BENCH host firstn
+  # Get crush tree
+  CRUSH_TREE_JSON=$(ceph "${CLI_OPTS[@]}" osd crush tree -f json)
+  # Link to CEPH-AUTO-BENCH
+  NODE=$(eval "echo \${CRUSH_TREE_JSON} | jq --raw-output '.[] | select(.name==\"${BENCH_OSD_TYPE}\") | .items[].name'")
+  for node in ${NODE}; do
+    ceph "${CLI_OPTS[@]}" osd crush link ${node} root=CEPH-AUTO-BENCH
+  done
+  # Adjust OSD number
+  for node in ${NODE}; do
+    local OSD=""
+    OSD=$(eval "echo \${CRUSH_TREE_JSON} | jq --raw-output '.[] | select(.name==\"${BENCH_OSD_TYPE}\")|  .items[] | select(.name==\"${node}\") | .items[].name'")
+    OSD=($OSD)
+    if [ "${OSD_NUM}" == "all" ]; then
+      return 0
+    else
+      local RM_OSD=$(expr "${#OSD[@]}" - "${OSD_NUM}")
+      local RM_OSD_ID=""
+    fi
+    until [ "${RM_OSD}" -le 0 ]; do
+      RM_OSD_ID=$(expr "${#OSD[@]}" - "${RM_OSD}")
+      ceph "${CLI_OPTS[@]}" osd crush rm "${OSD[${RM_OSD_ID}]}"
+      ((RM_OSD--))
+    done
+  done
+}
+
+function backup_crushmap {
+  # Backup crushmap
+  ceph "${CLI_OPTS[@]}" osd getcrushmap -o crushmap
+  #  Put on etcd
+  etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" mkdir "${CLUSTER_PATH}"/crushMap &>/dev/null || true
+  uuencode crushmap - | etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}"/crushMap/"${STAMP}"
+}
+
+function recovery_crushmap {
+  # Recovery crushmap
+  etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" get "${CLUSTER_PATH}"/crushMap/"${STAMP}" | uudecode -o crushmap
+  ceph "${CLI_OPTS[@]}" osd setcrushmap -i crushmap
+}
+
+function create_bench_pool {
+  # Create bench pool
+  ceph "${CLI_OPTS[@]}" osd pool rm ceph-auto-bench ceph-auto-bench --yes-i-really-really-mean-it
+  ceph "${CLI_OPTS[@]}" osd pool create ceph-auto-bench "${PG_NUM}" "${PG_NUM}" replicated ceph_auto_bench
+  ceph "${CLI_OPTS[@]}" osd pool set ceph-auto-bench size "${REPLICA}"
+}
+
+function remove_bench_pool {
+  # Remove bench pool
+  ceph "${CLI_OPTS[@]}" osd pool rm ceph-auto-bench ceph-auto-bench --yes-i-really-really-mean-it
+}

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/ceph.defaults
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/ceph.defaults
@@ -4,7 +4,7 @@
 # the key path will be prefixed by /ceph-config/$CLUSTER
 
 #osd
-/osd/osd_journal_size 2048
+/osd/osd_journal_size 5120
 
 # these 2 should be passed at runtime to the container.
 #/osd/cluster_network 198.100.128.0/19
@@ -17,7 +17,7 @@
 #crush
 /global/osd_pool_default_pg_num 16
 /global/osd_pool_default_pgp_num 16
-/global/osd_pool_default_size 1
+/global/osd_pool_default_size 2
 /osd/pool_default_crush_rule 0
 /osd/osd_crush_update_on_start true
 


### PR DESCRIPTION
1. Change ceph cluster default value by experience.
2. Flexible OSD numbers for ceph auto bench
3. Set default value of target_max_bytes for cache as 1TB.