### PR TITLE
Add new crush_type prod for production user.

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/cdx-env.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/cdx/cdx-env.sh
@@ -25,6 +25,7 @@
 # osd
 : "${CRUSH_TYPE:=space}"
 : "${PGs_PER_OSD:=32}"
+: "${RBD_PG_NUM:=128}"
 : "${OSD_INIT_MODE:=minimal}"
 : "${MAX_OSD:=99}"
 : "${OSD_MEM:=2048M}"


### PR DESCRIPTION
New crush_type prod:
1. Default replications rage from 1~3, according to the node numbers 1, 2 or 3+.
2. PG number of RBD pool as a fixed number, according to ENV variable $RBD_PG_NUM